### PR TITLE
CircleCI: Add flake8 static analysis to the testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,14 +33,22 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install -r requirements.txt
-            pip install torch torchvision
-            pip install tensorflow
-            pip install keras
+            pip install flake8 keras tensorflow torch torchvision
 
       - save_cache:
           paths:
             - ./venv
           key: v1-dependencies-{{ checksum "requirements.txt" }}
+
+      # Run the units tests from the mantraml library
+      - run:
+          name: run flake8 tests
+          command: |
+            . venv/bin/activate
+            # stop the build if there are Python syntax errors or undefined names
+            flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+            # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+            flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
       # Run the units tests from the mantraml library
       - run:


### PR DESCRIPTION
Add [flake8](http://flake8.pycqa.org) tests to find Python syntax errors and undefined names.

__E901,E999,F821,F822,F823__ are the "_showstopper_" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree