### PR TITLE
flake8 —exclude=./venv/lib/python3.6/site-packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,9 +46,9 @@ jobs:
           command: |
             . venv/bin/activate
             # stop the build if there are Python syntax errors or undefined names
-            flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+            flake8 . --count --exclude=./venv/lib/python3.6/site-packages --select=E901,E999,F821,F822,F823 --show-source --statistics
             # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-            flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+            flake8 . --count --exclude=./venv/lib/python3.6/site-packages --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
       # Run the units tests from the mantraml library
       - run:


### PR DESCRIPTION
Only test our code, not the code of our pip imports.